### PR TITLE
Add partial support for “modules” preset option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
 /* eslint-disable import/no-dynamic-require */
-module.exports = () => {
-	const plugins = require(`./plugins/best-match`)
+const determineModulesPlugin = require('./plugins/modules');
+
+module.exports = (context, options) => {
+	const plugins = determineModulesPlugin(options)
+		.concat(require(`./plugins/best-match`))
 		.map(module => require(module));
 
 	return {plugins};

--- a/package-hash.js
+++ b/package-hash.js
@@ -1,7 +1,10 @@
 'use strict';
 const packageHash = require('package-hash');
+const determineModulesPlugin = require('./plugins/modules');
 
-const plugins = require('./plugins/best-match')
+const plugins = Object.keys(determineModulesPlugin.supported)
+	.map(k => determineModulesPlugin.supported[k])
+	.concat(require('./plugins/best-match'))
 	.map(module => require.resolve(`${module}/package.json`));
 
 module.exports = packageHash.sync([require.resolve('./package.json')].concat(plugins));

--- a/plugins/4.json
+++ b/plugins/4.json
@@ -4,7 +4,6 @@
   "babel-plugin-transform-async-to-generator",
   "babel-plugin-transform-es2015-destructuring",
   "babel-plugin-transform-es2015-function-name",
-  "babel-plugin-transform-es2015-modules-commonjs",
   "babel-plugin-transform-es2015-parameters",
   "babel-plugin-transform-es2015-spread",
   "babel-plugin-transform-es2015-sticky-regex",

--- a/plugins/6.json
+++ b/plugins/6.json
@@ -1,6 +1,5 @@
 [
   "babel-plugin-syntax-trailing-function-commas",
   "babel-plugin-transform-async-to-generator",
-  "babel-plugin-transform-es2015-modules-commonjs",
   "babel-plugin-transform-exponentiation-operator"
 ]

--- a/plugins/8.json
+++ b/plugins/8.json
@@ -1,3 +1,1 @@
-[
-  "babel-plugin-transform-es2015-modules-commonjs"
-]
+[]

--- a/plugins/modules.js
+++ b/plugins/modules.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const supported = {
+	commonjs: 'babel-plugin-transform-es2015-modules-commonjs'
+};
+
+module.exports = function (options) {
+	const modules = options && options.modules !== null ? options.modules : 'commonjs';
+
+	if (modules === false) {
+		return [];
+	}
+
+	const plugin = supported[modules];
+
+	if (!plugin) {
+		throw new Error('@ava/stage-4 only supports commonjs module transformation.');
+	}
+
+	return [plugin];
+};
+
+module.exports.supported = supported;

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,21 @@ Add `@ava/stage-4` to your [Babel] presets.
 Require `@ava/babel-preset-stage-4/package-hash` to get a combined hash for the installed version of the preset, as well as the plugins that were selected for the active Node.js version.
 
 
+## Options
+
+For more information on setting options for a preset, refer to the [plugin/preset options] documentation.
+
+
+### `modules`
+
+`"commonjs" | false`, defaults to `"commonjs"`.
+
+Enable transformation of ES6 module syntax to another module type.
+
+Setting this to `false` will not transform modules.
+
+
 [AVA]: https://ava.li
 [Babel]: https://babeljs.io
+[plugin/preset options]: http://babeljs.io/docs/plugins/#plugin-preset-options
 [node.green]: http://node.green


### PR DESCRIPTION
Only support transforming ES module to “commonjs” or to disable the module transformation. "babel-preset-env" supports other legacy module types which are not relevant for AVA.